### PR TITLE
vendor: themes: set notification_action_list_dark color in all themes

### DIFF
--- a/google/themes/Bl4ckAndYell0/res/values/colors.xml
+++ b/google/themes/Bl4ckAndYell0/res/values/colors.xml
@@ -72,7 +72,8 @@
 
     <color name="notification_material_background_color">@*android:color/omni_color7</color>
     <color name="notification_default_color">@*android:color/omni_text1</color> <!-- Gray 600 -->
-    <color name="notification_action_list">@*android:color/omni_color7</color>
+    <color name="notification_action_list">@*android:color/omni_color1</color>
+    <color name="notification_action_list_dark">@*android:color/omni_color2</color>
     <color name="notification_primary_text_color_light">@*android:color/omni_text1</color>
     <color name="notification_secondary_text_color_light">@*android:color/omni_text2</color>
     <color name="notification_progress_background_color">@*android:color/omni_text2</color>

--- a/google/themes/DarknessMeister/res/values/colors.xml
+++ b/google/themes/DarknessMeister/res/values/colors.xml
@@ -71,7 +71,8 @@
 
     <color name="notification_material_background_color">@*android:color/omni_color7</color>
     <color name="notification_default_color">@*android:color/omni_text1</color> <!-- Gray 600 -->
-    <color name="notification_action_list">@*android:color/omni_color7</color>
+    <color name="notification_action_list">@*android:color/omni_color1</color>
+    <color name="notification_action_list_dark">@*android:color/omni_color2</color>
     <color name="notification_primary_text_color_light">@*android:color/omni_text1</color>
     <color name="notification_secondary_text_color_light">@*android:color/omni_text2</color>
     <color name="notification_progress_background_color">@*android:color/omni_text2</color>

--- a/google/themes/FromHell/res/values/colors.xml
+++ b/google/themes/FromHell/res/values/colors.xml
@@ -73,7 +73,8 @@
 
     <color name="notification_material_background_color">@*android:color/omni_color7</color>
     <color name="notification_default_color">@*android:color/omni_text1</color> <!-- Gray 600 -->
-    <color name="notification_action_list">@*android:color/omni_color7</color>
+    <color name="notification_action_list">@*android:color/omni_color1</color>
+    <color name="notification_action_list_dark">@*android:color/omni_color2</color>
     <color name="notification_primary_text_color_light">@*android:color/omni_text1</color>
     <color name="notification_secondary_text_color_light">@*android:color/omni_text2</color>
     <color name="notification_progress_background_color">@*android:color/omni_text2</color>

--- a/google/themes/OmniTheme/res/values/colors.xml
+++ b/google/themes/OmniTheme/res/values/colors.xml
@@ -71,7 +71,8 @@
 
     <color name="notification_material_background_color">@*android:color/omni_color7</color>
     <color name="notification_default_color">@*android:color/omni_text1</color> <!-- Gray 600 -->
-    <color name="notification_action_list">@*android:color/omni_color7</color>
+    <color name="notification_action_list">@*android:color/omni_color1</color>
+    <color name="notification_action_list_dark">@*android:color/omni_color2</color>
     <color name="notification_primary_text_color_light">@*android:color/omni_text1</color>
     <color name="notification_secondary_text_color_light">@*android:color/omni_text2</color>
     <color name="notification_progress_background_color">@*android:color/omni_text2</color>

--- a/google/themes/SluttyPink/res/values/colors.xml
+++ b/google/themes/SluttyPink/res/values/colors.xml
@@ -71,7 +71,8 @@
 
     <color name="notification_material_background_color">@*android:color/omni_color7</color>
     <color name="notification_default_color">@*android:color/omni_text1</color> <!-- Gray 600 -->
-    <color name="notification_action_list">@*android:color/omni_color7</color>
+    <color name="notification_action_list">@*android:color/omni_color1</color>
+    <color name="notification_action_list_dark">@*android:color/omni_color2</color>
     <color name="notification_primary_text_color_light">@*android:color/omni_text1</color>
     <color name="notification_secondary_text_color_light">@*android:color/omni_text2</color>
     <color name="notification_progress_background_color">@*android:color/omni_text2</color>

--- a/google/themes/SmokedGreen/res/values/colors.xml
+++ b/google/themes/SmokedGreen/res/values/colors.xml
@@ -71,7 +71,8 @@
 
     <color name="notification_material_background_color">@*android:color/omni_color7</color>
     <color name="notification_default_color">@*android:color/omni_text1</color> <!-- Gray 600 -->
-    <color name="notification_action_list">@*android:color/omni_color7</color>
+    <color name="notification_action_list">@*android:color/omni_color1</color>
+    <color name="notification_action_list_dark">@*android:color/omni_color2</color>
     <color name="notification_primary_text_color_light">@*android:color/omni_text1</color>
     <color name="notification_secondary_text_color_light">@*android:color/omni_text2</color>
     <color name="notification_progress_background_color">@*android:color/omni_text2</color>

--- a/google/themes/ZeroZero/res/values/colors.xml
+++ b/google/themes/ZeroZero/res/values/colors.xml
@@ -71,7 +71,8 @@
 
     <color name="notification_material_background_color">@*android:color/omni_color7</color>
     <color name="notification_default_color">@*android:color/omni_text1</color> <!-- Gray 600 -->
-    <color name="notification_action_list">@*android:color/omni_color7</color>
+    <color name="notification_action_list">@*android:color/omni_color1</color>
+    <color name="notification_action_list_dark">@*android:color/omni_color2</color>
     <color name="notification_primary_text_color_light">@*android:color/omni_text1</color>
     <color name="notification_secondary_text_color_light">@*android:color/omni_text2</color>
     <color name="notification_progress_background_color">@*android:color/omni_text2</color>


### PR DESCRIPTION
fix for heads-up notification button bg color

Change-Id: Ib8266e065d38d60412564121c5aa5a330a29b81e